### PR TITLE
logrus formatter not exportable anymore

### DIFF
--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"time"
 )
 
 // Formatter generates json in logstash format.
@@ -44,7 +45,7 @@ func (f *LogstashFormatter) FormatWithPrefix(entry *logrus.Entry, prefix string)
 	timeStampFormat := f.TimestampFormat
 
 	if timeStampFormat == "" {
-		timeStampFormat = logrus.DefaultTimestampFormat
+		timeStampFormat = time.RFC3339
 	}
 
 	fields["@timestamp"] = entry.Time.Format(timeStampFormat)


### PR DESCRIPTION
Due to logrus making the DefaultTimestampFormat not exportable anymore, now setting the default time to time.RFC3339. Which is the format for logrus